### PR TITLE
Forward MSI/MTI to supervisor priv.

### DIFF
--- a/rustsbi-k210/src/execute.rs
+++ b/rustsbi-k210/src/execute.rs
@@ -41,6 +41,12 @@ pub fn execute_supervisor(supervisor_mepc: usize, a0: usize, a1: usize) -> ! {
                 let ctx = rt.context_mut();
                 feature::call_supervisor_interrupt(ctx)
             },
+            GeneratorState::Yielded(MachineTrap::MachineTimer()) => {
+                feature::forward_supervisor_timer()
+            },
+            GeneratorState::Yielded(MachineTrap::MachineSoft()) => {
+                feature::forward_supervisor_soft()
+            },
             // todo：编写样例，验证store page fault和instruction page fault
             GeneratorState::Yielded(MachineTrap::InstructionFault(addr)) => {
                 let ctx = rt.context_mut();

--- a/rustsbi-k210/src/feature.rs
+++ b/rustsbi-k210/src/feature.rs
@@ -6,6 +6,12 @@ mod transfer_trap;
 
 pub use emulate_rdtime::emulate_rdtime;
 pub use sfence_vma::emulate_sfence_vma;
-pub use supervisor_interrupt::{call_supervisor_interrupt, emulate_sbi_rustsbi_k210_sext, preprocess_supervisor_external};
+pub use supervisor_interrupt::{
+    call_supervisor_interrupt,
+    emulate_sbi_rustsbi_k210_sext,
+    preprocess_supervisor_external,
+    forward_supervisor_soft,
+    forward_supervisor_timer,
+};
 pub use delegate_page_fault::is_page_fault;
 pub use transfer_trap::{should_transfer_trap, do_transfer_trap};

--- a/rustsbi-k210/src/feature/supervisor_interrupt.rs
+++ b/rustsbi-k210/src/feature/supervisor_interrupt.rs
@@ -72,21 +72,19 @@ pub fn preprocess_supervisor_external(ctx: &mut SupervisorContext) {
     }
 }
 
-// XX: Should we do this code?
-/*
-Trap::Interrupt(Interrupt::MachineSoft) => {
+pub fn forward_supervisor_timer() {
+    // Forward to S-level timer interrupt
+    unsafe {
+        mip::set_stimer(); // set S-timer interrupt flag
+        mie::clear_mext(); // Ref: rustsbi Pull request #5
+        mie::clear_mtimer(); // mask M-timer interrupt
+    }
+}
+
+pub fn forward_supervisor_soft() {
     // Forward to S-level software interrupt
     unsafe {
         mip::set_ssoft(); // set S-soft interrupt flag
         mie::clear_msoft(); // mask M-soft interrupt
     }
 }
-Trap::Interrupt(Interrupt::MachineTimer) => {
-    // Forward to S-level timer interrupt
-    unsafe {
-        mip::set_stimer(); // set S-timer interrupt flag
-        mie::clear_mext(); // Ref: Pull request #5
-        mie::clear_mtimer(); // mask M-timer interrupt
-    }
-}
-*/

--- a/rustsbi-k210/src/runtime.rs
+++ b/rustsbi-k210/src/runtime.rs
@@ -60,6 +60,8 @@ impl Generator for Runtime {
             Trap::Exception(Exception::LoadFault) => MachineTrap::LoadFault(mtval),
             Trap::Exception(Exception::StoreFault) => MachineTrap::StoreFault(mtval),
             Trap::Interrupt(Interrupt::MachineExternal) => MachineTrap::ExternalInterrupt(),
+            Trap::Interrupt(Interrupt::MachineTimer) => MachineTrap::MachineTimer(),
+            Trap::Interrupt(Interrupt::MachineSoft) => MachineTrap::MachineSoft(),
             e => panic!("unhandled exception: {:?}! mtval: {:#x?}, ctx: {:#x?}", e, mtval, self.context)
         };
         GeneratorState::Yielded(trap)
@@ -72,6 +74,8 @@ pub enum MachineTrap {
     SbiCall(),
     IllegalInstruction(),
     ExternalInterrupt(),
+    MachineTimer(),
+    MachineSoft(),
     InstructionFault(usize),
     LoadFault(usize),
     StoreFault(usize),


### PR DESCRIPTION
Added two new types of machine traps:
* `MachineTrap::MachineTimer`
* `MachineTrap::MachineSoft`

Now the runtime is able to yield them:
```rust
impl Generator for Runtime {
            ...
            Trap::Interrupt(Interrupt::MachineTimer) => MachineTrap::MachineTimer(),
            Trap::Interrupt(Interrupt::MachineSoft) => MachineTrap::MachineSoft(),
            ...
}
```

When they are matched in two added arms in `execute::execute_supervisor`, two functions will be called:
```rust
            GeneratorState::Yielded(MachineTrap::MachineTimer()) => {
                feature::forward_supervisor_timer()
            },
            GeneratorState::Yielded(MachineTrap::MachineSoft()) => {
                feature::forward_supervisor_soft()
            },
``` 

You can find their implementation(I just copied & pasted legacy code) below:
```rust
// feature/supervisor_interrupt.rs

pub fn forward_supervisor_timer() {
    // Forward to S-level timer interrupt
    unsafe {
        mip::set_stimer(); // set S-timer interrupt flag
        mie::clear_mext(); // Ref: rustsbi Pull request #5
        mie::clear_mtimer(); // mask M-timer interrupt
    }
}
pub fn forward_supervisor_soft() {
    // Forward to S-level software interrupt
    unsafe {
        mip::set_ssoft(); // set S-soft interrupt flag
        mie::clear_msoft(); // mask M-soft interrupt
    }
}

```

The timer has passed the test in rCore-Tutorial-v3 while the soft has not been tested due to the lack of the SMP execution environment, I will apply myself to check it later.